### PR TITLE
Atualização do exemplo com a mudança do nomes das classes de UF

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ public class NFeConfigTeste extends NFeConfig {
     private KeyStore keyStoreCadeia = null;
 
     @Override
-    public NFUnidadeFederativa getCUF() {
-        return NFUnidadeFederativa.SC;
+    public DFUnidadeFederativa getCUF() {
+        return DFUnidadeFederativa.SC;
     }
 
     @Override


### PR DESCRIPTION
Atualização do exemplo com a alteração do nome das classes de Uf que foi de "NFUnidadeFederativa" para "DFUnidadeFederativa"